### PR TITLE
TER-142 use harvest image & setup make targets

### DIFF
--- a/.github/workflows/action-harvest-check.yaml
+++ b/.github/workflows/action-harvest-check.yaml
@@ -5,40 +5,21 @@ on:
       - main
 
 jobs:
-  create_artifact:
+  checks:
     name: Test Harvest
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main 
-        uses: actions/checkout@v3
-        with:
-          path: farm
-        
-      - name: Checkout terrarium tools
-        uses: actions/checkout@v3
-        with:
-          repository: cldcvr/terrarium
-          ref: main
-          token: ${{ secrets.PAT_TOKEN }}
-          path: tools
+      - uses: actions/checkout@v3
 
       - name: Download latest release asset
+        run: |
+          make pull-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p /home/runner/work/terrarium-farm/terrarium-farm/tools/data
-          cd /home/runner/work/terrarium-farm/terrarium-farm/farm
-          gh release download latest
-          cp ./terrarium_farm.psql /home/runner/work/terrarium-farm/terrarium-farm/tools/data/cc_terrarium.psql
 
       - name: Harvest farm sql dump
         run: |
-          rm -rf /home/runner/work/terrarium-farm/terrarium-farm/tools/examples/farm
-          mkdir /home/runner/work/terrarium-farm/terrarium-farm/tools/examples/farm
-          cp -r /home/runner/work/terrarium-farm/terrarium-farm/farm/* /home/runner/work/terrarium-farm/terrarium-farm/tools/examples/farm
-          cd /home/runner/work/terrarium-farm/terrarium-farm/tools/
-          export TR_DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-          make docker-init docker-harvest db-dump
-
-          
+          make harvest db-dump
+        env:
+          TR_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}

--- a/.github/workflows/action-harvest-db-dump.yaml
+++ b/.github/workflows/action-harvest-db-dump.yaml
@@ -10,42 +10,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main 
-        uses: actions/checkout@v3
-        with:
-          path: farm
-        
-      - name: Checkout terrarium tools
-        uses: actions/checkout@v3
-        with:
-          repository: cldcvr/terrarium
-          ref: main
-          token: ${{ secrets.PAT_TOKEN }}
-          path: tools
+      - uses: actions/checkout@v3
 
       - name: Download latest release asset
+        run: |
+          make pull-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p /home/runner/work/terrarium-farm/terrarium-farm/tools/data
-          cd /home/runner/work/terrarium-farm/terrarium-farm/farm
-          gh release download latest
-          cp ./terrarium_farm.psql /home/runner/work/terrarium-farm/terrarium-farm/tools/data/cc_terrarium.psql
 
       - name: Generate farm sql dump
         run: |
-          rm -rf /home/runner/work/terrarium-farm/terrarium-farm/tools/examples/farm
-          mkdir /home/runner/work/terrarium-farm/terrarium-farm/tools/examples/farm
-          cp -r /home/runner/work/terrarium-farm/terrarium-farm/farm/* /home/runner/work/terrarium-farm/terrarium-farm/tools/examples/farm
-          cd /home/runner/work/terrarium-farm/terrarium-farm/tools/
-          ls -la ./data
-          export TR_DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-          make docker-init docker-harvest db-dump 
+          make harvest db-dump
+        env:
+          TR_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
         
       - name: Create release asset
         run: |
-          mkdir /home/runner/work/terrarium-farm/terrarium-farm/release-assets
-          cp /home/runner/work/terrarium-farm/terrarium-farm/tools/data/cc_terrarium.psql /home/runner/work/terrarium-farm/terrarium-farm/release-assets/terrarium_farm.psql
+          mkdir release-assets
+          cp data/cc_terrarium.psql release-assets/terrarium_farm.psql
+          ls -la release-assets
 
       - name: Release
         uses: "marvinpinto/action-automatic-releases@latest"
@@ -55,5 +38,4 @@ jobs:
           prerelease: true
           title: "Farm Release"
           files: |
-            /home/runner/work/terrarium-farm/terrarium-farm/release-assets/terrarium_farm.psql
-      
+            release-assets/terrarium_farm.psql

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ cache_data
 __debug_bin
 .bin
 terraform/tr-private-sources.tf
+data/*.*sql
 
 ### Protobuf Dependencies ###
 api/pkg/pb/google/*

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,48 @@
-.PHONY: clean_tf start-db harvest stop-db
+TERRAFORM_DIR := ./modules
 
-TERRAFORM_DIR := ./terraform
+POSTGRES_CONTAINER := postgres
+POSTGRES_DB := cc_terrarium
+POSTGRES_USER := postgres
+FARM_DB_DUMP_FILE := $(POSTGRES_DB).psql
 
+ifeq ($(FARM_VERSION),)
+FARM_VERSION := latest
+endif
+
+.PHONY: clean_tf
 clean_tf:
 	rm -rf $(TERRAFORM_DIR)/.terraform
 	rm -f $(TERRAFORM_DIR)/.terraform.lock.hcl
 
+.PHONY: start-db
 start-db:  ## Starts database in docker container
 	docker compose up -d postgres
 
-harvest:
+.PHONY: db-dump
+db-dump: start-db  ## Target for dumping PostgreSQL database to a file
+	docker compose exec -T $(POSTGRES_CONTAINER) pg_dump --column-inserts -U $(POSTGRES_USER) -f /docker-entrypoint-initdb.d/$(FARM_DB_DUMP_FILE) -Fc $(POSTGRES_DB)
+
+.PHONY: harvest
+harvest:  ## Process the farm code and insert rows to database
 	docker compose run --rm harvester
 
-stop-db:  ## Stops and removes database container
+.PHONY: stop-db
+stop-db:  ## Stops database container
 	docker compose down
+
+.PHONY: stop-db
+stop-clean-db:  ## Stops database container, deletes db volume and the sql dump file
+	docker compose down -v
+	rm -f data/$(FARM_DB_DUMP_FILE)
+
+data/$(FARM_DB_DUMP_FILE):
+	$(call pull-release)
+
+.PHONY: pull-release
+pull-release:
+	@echo "Downloading db dump from the latest terrarium-farm release..."
+	@gh release download $(FARM_VERSION) --clobber -p 'terrarium_farm.psql' -O data/$(FARM_DB_DUMP_FILE)
+
+.PHONY: help
+help:
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -6,21 +6,23 @@ Terraform templates to be used for seeding should be placed in the ./terraform d
 
 ## Modes of Operation
 
-#### Local database
+### Local database
 
-Use the "make start-db" command to start a local Postgres container where the database will be created on a docker volume.
+Use the `make start-db` command to start a local Postgres container where the database will be created on a docker volume.
 These environment variables are required:
+
 ```sh
 TR_DB_PASSWORD= # Choose a custom password. This variable is used by docker-compose to set password in postgres local server and is used in API to connect to the database
 ```
 
 Then run "make harvest" to populate the local database.
 
-#### Remote database
+### Remote database
 
 In this mode, you are loading new information into a remote Postgres database - presumably a DB instance that is over a long period of time to facilitate Terrarium operation.
 
 These environment variables are required:
+
 ```sh
 TR_DB_HOST= # hostname of remote database instance
 TR_DB_PORT= # port number (defaults to 5432)
@@ -30,3 +32,37 @@ TR_DB_PASSWORD= # password
 ```
 
 Then run "make harvest" to populate the remote database.
+
+### Harvest Over Latest Release
+
+To pull data-dump from the latest release, and run the harvest command on the existing data, use the following command:
+
+1. Stop the current database and erase existing data.
+
+    ```sh
+    make stop-clean-db
+    ```
+
+2. Pull data-dump from the latest Terrarium release.
+
+    ```sh
+    make pull-release
+    ```
+
+3. Execute the harvest command to update the database.
+
+    ```sh
+    make harvest
+    ```
+
+Furthermore, to get a list of available make targets, use the command:
+
+```sh
+make help
+```
+
+## Prerequisite
+
+- Golang >= 1.20
+- Docker & Docker Compose
+- GitHub CLI (gh)

--- a/data/init.sh
+++ b/data/init.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Specify the path to the database dump file
+dump_file="/docker-entrypoint-initdb.d/cc_terrarium.psql"
+
+# Check if the dump file exists
+if [ ! -f "$dump_file" ]; then
+  pwd
+  echo "File $dump_file not found. Skipping database restore."
+  exit 0
+fi
+
+# Restore the database using pg_restore command
+pg_restore -U $POSTGRES_USER -d $POSTGRES_DB -W $dump_file
+
+# Check the exit status of the pg_restore command
+if [ $? -ne 0 ]; then
+  echo "Error: Database restore failed."
+  exit 1
+else
+  echo "Database restore completed successfully."
+fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - "5432:5432"
 
   harvester:
-    image: cldcvr/terrarium-seeder
+    image: cldcvr/terrarium-farm-harvester
     environment:
       # DB config
       TR_DB_HOST: ${TR_DB_HOST:-postgres}
@@ -27,5 +27,6 @@ services:
       TR_DB_SSL_MODE: ${TR_DB_SSL_MODE:-}
       TR_DB_PASSWORD: ${TR_DB_PASSWORD:-}
     volumes:
-      - ./terraform:/app/terraform
-      - ./cache_data:/app/cache_data
+      - .:/app/farm
+    depends_on:
+      - postgres

--- a/modules/.terraform.lock.hcl
+++ b/modules/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
   constraints = ">= 3.0.0, >= 3.29.0, >= 3.72.0, >= 3.74.0, >= 4.0.0, >= 4.28.0, >= 4.35.0, < 5.0.0"
   hashes = [
-    "h1:DWVybabEz2gCyQkRM9zop1SKTG1tkH7+ruekC9KQM5w=",
+    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
     "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
     "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.2"
   constraints = ">= 2.0.0"
   hashes = [
-    "h1:y+6FsU2STOpx6L6JOon4DVZoZPQgNoR2xR2WQ/EVxcQ=",
+    "h1:Vl0aixAYTV/bjathX7VArC5TVNkxBCsi3Vq7R4z1uvc=",
     "zh:2487e498736ed90f53de8f66fe2b8c05665b9f8ff1506f751c5ee227c7f457d1",
     "zh:3d8627d142942336cf65eea6eb6403692f47e9072ff3fa11c3f774a3b93130b3",
     "zh:434b643054aeafb5df28d5529b72acc20c6f5ded24decad73b98657af2b53f4f",
@@ -48,7 +48,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.1.2"
   constraints = "2.1.2"
   hashes = [
-    "h1:s48NaBxKrs8G774KL7+hQiqaTupphxCSHAmgE/6DoZg=",
+    "h1:axFN2JRP+iDo8EAhCfnA3fRUCB5S5x4zCKkivWLNN+Y=",
     "zh:09bd2b6f33a040c3fd59d82c9768b886b8c82163e31ec92dc1b747229d0548df",
     "zh:09f209fa57ad5d01f04c458f1719b42958ca5e0fc2eca63d9ec29f92c77a29f8",
     "zh:0bfc627539500ffb2a41a2f8a5ea7f6fb1d76367b11bbf9489b483b9e8dfff8f",
@@ -66,7 +66,7 @@ provider "registry.terraform.io/hashicorp/helm" {
 provider "registry.terraform.io/hashicorp/http" {
   version = "3.4.0"
   hashes = [
-    "h1:gLCUuF4yN2uNA0FjVXCJd65ZnI8VKJVsZEYKRem1JUM=",
+    "h1:h3URn6qAnP36OlSqI1tTuKgPL3GriZaJia9ZDrUvRdg=",
     "zh:56712497a87bc4e91bbaf1a5a2be4b3f9cfa2384baeb20fc9fad0aff8f063914",
     "zh:6661355e1090ebacab16a40ede35b029caffc279d67da73a000b6eecf0b58eba",
     "zh:67b92d343e808b92d7e6c3bbcb9b9d5475fecfed0836963f7feb9d9908bd4c4f",
@@ -83,29 +83,29 @@ provider "registry.terraform.io/hashicorp/http" {
 }
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
-  version     = "2.21.1"
+  version     = "2.22.0"
   constraints = ">= 2.10.0"
   hashes = [
-    "h1:7cCH+Wsg2lFTpsTleJ7MewkrYfFlxU1l4HlLWP8wzFw=",
-    "zh:156a437d7edd6813e9cb7bdff16ebce28cec08b07ba1b0f5e9cec029a217bc27",
-    "zh:1a21c255d8099e303560e252579c54e99b5f24f2efde772c7e39502c62472605",
-    "zh:27b2021f86e5eaf6b9ee7c77d7a9e32bc496e59dd0808fb15a5687879736acf6",
-    "zh:31fa284c1c873a85c3b5cfc26cf7e7214d27b3b8ba7ea5134ab7d53800894c42",
-    "zh:4be9cc1654e994229c0d598f4e07487fc8b513337de9719d79b45ce07fc4e123",
-    "zh:5f684ed161f54213a1414ac71b3971a527c3a6bfbaaf687a7c8cc39dcd68c512",
-    "zh:6d58f1832665c256afb68110c99c8112926406ae0b64dd5f250c2954fc26928e",
-    "zh:9dadfa4a019d1e90decb1fab14278ee2dbefd42e8f58fe7fa567a9bf51b01e0e",
-    "zh:a68ce7208a1ef4502528efb8ce9f774db56c421dcaccd3eb10ae68f1324a6963",
-    "zh:acdd5b45a7e80bc9d254ad0c2f9cb4715104117425f0d22409685909a790a6dd",
+    "h1:b6Wj111/wsMNg8FrHFXrf4mCZFtSXKHx4JvbZh3YTCY=",
+    "zh:1eac662b1f238042b2068401e510f0624efaf51fd6a4dd9c49d710a49d383b61",
+    "zh:4c35651603493437b0b13e070148a330c034ac62c8967c2de9da6620b26adca4",
+    "zh:50c0e8654efb46e3a3666c638ca2e0c8aec07f985fbc80f9205bed960386dc9b",
+    "zh:5f65194ddd6ea7e89b378297d882083a4b84962edb35dd35752f0c7e9d6282a0",
+    "zh:6fc0c2d65864324edde4db84f528268065df58229fc3ee321626687b0e603637",
+    "zh:73c58d007aba7f67c0aa9029794e10c2517bec565b7cb57d0f5948ea3f30e407",
+    "zh:7d6fc9d3c1843baccd2e1fc56317925a2f9df372427d30fcb5052d123adc887a",
+    "zh:a0ad9eb863b51586ea306c5f2beef74476c96684aed41a3ee99eb4b6d8898d01",
+    "zh:e218fcfbf4994ff741408a023a9d9eb6c697ce9f63ce5540d3b35226d86c963e",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fb451e882118fe92e1cb2e60ac2d77592f5f7282b3608b878b5bdc38bbe4fd5b",
+    "zh:f95625f317795f0e38cc6293dd31c85863f4e225209d07d1e233c50d9295083c",
+    "zh:f96e0923a632bc430267fe915794972be873887f5e761ed11451d67202e256c8",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.1"
   hashes = [
-    "h1:wqgRvlyVIbkCeCQs+5jj6zVuQL0KDxZZtNofGqqlSdI=",
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
     "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
@@ -125,7 +125,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = ">= 3.1.0"
   hashes = [
-    "h1:6FVyQ/aG6tawPam6B+oFjgdidKd83uG9n7dOSQ66HBA=",
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
     "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
@@ -144,7 +144,7 @@ provider "registry.terraform.io/hashicorp/random" {
 provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
-    "h1:12Bac8B6Aq2+18xe8iqp5iYytav2Bw+jG43z/VaK5zI=",
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
     "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
@@ -162,7 +162,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.4"
   constraints = ">= 3.0.0"
   hashes = [
-    "h1:bNsvpX5EGuVxgGRXBQVLXlmq40PdoLp8Rfuh1ZmV7yY=",
+    "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
     "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",


### PR DESCRIPTION
- use pre built DH image `cldcvr/terrarium-farm-harvester`
- add make targets to harvest the farm and manage db
- add setup steps to readme.md
- update GitHub Action to use the make targets
