### PR TITLE
TER-348 remove `--column-inserts` from the pg_dump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ start-db:  ## Starts database in docker container
 
 .PHONY: db-dump
 db-dump: start-db  ## Target for dumping PostgreSQL database to a file
-	docker compose exec -T $(POSTGRES_CONTAINER) pg_dump --column-inserts -U $(POSTGRES_USER) -f /docker-entrypoint-initdb.d/$(FARM_DB_DUMP_FILE) -Fc $(POSTGRES_DB)
+	docker compose exec -T $(POSTGRES_CONTAINER) pg_dump -U $(POSTGRES_USER) -f /docker-entrypoint-initdb.d/$(FARM_DB_DUMP_FILE) -Fc $(POSTGRES_DB)
 	docker compose exec -T $(POSTGRES_CONTAINER) pg_dump -Z 9 --column-inserts --rows-per-insert=100 --data-only --exclude-table=taxonomies -U $(POSTGRES_USER) -f /docker-entrypoint-initdb.d/$(FARM_DB_DUMP_FILE_SQL_ZIP) -Fp $(POSTGRES_DB)
 
 .PHONY: harvest


### PR DESCRIPTION
to make it faster for fresh restore.